### PR TITLE
Sort tasks of type Deadline and Event by time

### DIFF
--- a/src/main/java/duke/DukeFx.java
+++ b/src/main/java/duke/DukeFx.java
@@ -188,6 +188,9 @@ public class DukeFx extends Application {
             return delete(input);
         case "find":
             return find(input);
+        case "sort":
+            tasks.sortByTime();
+            return "Your tasks have been sorted.\n" + tasks.toString();
         default:
             // Message for unrecognised task type
             return "☹ OOPS!!! I'm sorry, but I don't know what that means :-(";

--- a/src/main/java/duke/task/Deadline.java
+++ b/src/main/java/duke/task/Deadline.java
@@ -37,4 +37,20 @@ public class Deadline extends Task {
         }
         return false;
     }
+
+    @Override
+    public int compareTo(Task task) {
+        if (task instanceof Todo) {
+            // always put todo task before other types
+            // do not sort it for now
+            return -1;
+        } else if (task instanceof Event) {
+            Event eventTask = (Event) task;
+            return this.by.compareTo(eventTask.at);
+        } else {
+            assert task instanceof Deadline : "Invalid Task type: " + task;
+            Deadline deadlineTask = (Deadline) task;
+            return this.by.compareTo(deadlineTask.by);
+        }
+    }
 }

--- a/src/main/java/duke/task/Event.java
+++ b/src/main/java/duke/task/Event.java
@@ -36,4 +36,20 @@ public class Event extends Task {
         }
         return false;
     }
+
+    @Override
+    public int compareTo(Task task) {
+        if (task instanceof Todo) {
+            // always put todo task before other types
+            // do not sort it for now
+            return -1;
+        } else if (task instanceof Event) {
+            Event eventTask = (Event) task;
+            return this.at.compareTo(eventTask.at);
+        } else {
+            assert task instanceof Deadline : "Invalid Task type: " + task;
+            Deadline deadlineTask = (Deadline) task;
+            return this.at.compareTo(deadlineTask.by);
+        }
+    }
 }

--- a/src/main/java/duke/task/Task.java
+++ b/src/main/java/duke/task/Task.java
@@ -3,7 +3,7 @@ package duke.task;
 /**
  * A task representation for Duke.
  */
-public class Task {
+public abstract class Task implements Comparable<Task> {
     protected String description;
     protected boolean isDone;
 
@@ -55,4 +55,7 @@ public class Task {
         }
         return false;
     }
+
+    @Override
+    public abstract int compareTo(Task task);
 }

--- a/src/main/java/duke/task/TaskList.java
+++ b/src/main/java/duke/task/TaskList.java
@@ -1,12 +1,14 @@
 package duke.task;
 
 import java.util.ArrayList;
+import java.util.Collections;
 
 /**
  * An array list of tasks.
  */
 public class TaskList extends ArrayList<Task> {
     private ArrayList<Task> list = new ArrayList<>();
+
     /**
      * Create an empty list of task.
      */
@@ -146,5 +148,14 @@ public class TaskList extends ArrayList<Task> {
             result.append("There is not task matched.");
         }
         return result.toString();
+    }
+
+    /**
+     * Sort the tasks by time.
+     *
+     * Todo tasks are not sorted and always put in front.
+     */
+    public void sortByTime() {
+        Collections.<Task>sort(list);
     }
 }

--- a/src/main/java/duke/task/Todo.java
+++ b/src/main/java/duke/task/Todo.java
@@ -27,4 +27,11 @@ public class Todo extends Task {
         }
         return false;
     }
+
+    @Override
+    public int compareTo(Task task) {
+        // always put todo task before other types
+        // do not sort it for now
+        return -1;
+    }
 }


### PR DESCRIPTION
Sort tasks of type `Deadline` and `Event` by time.

Tasks of type `Deadline` and `Event` are sorted by their `LocalDate` of `by` and `at`  respectively.
Tasks of type `Todo` are left unsorted and put in front arbitrarily.

Secondary sorting by description can be a future extension.